### PR TITLE
[fix] cases with bot trigger when casing and punctuation interfere

### DIFF
--- a/api/commands/triggers.py
+++ b/api/commands/triggers.py
@@ -1,11 +1,12 @@
 from src.pymon_assistant.tasks.chat import chat
 from api.utils import (
-    format_history, 
-    fetch_message, 
+    format_history,
+    fetch_message,
     clean_message,
+    get_raw_text,
 )
 
-QUESTION_STARTER = "tell me pymon, "
+QUESTION_STARTER = "tell me pymon"
 
 
 def get_llm_response(message, history=[]):
@@ -28,7 +29,9 @@ def qna_trigger(message):
     bool:
         True if the message is a question to Pymon, False otherwise
     """
-    if message.content.startswith(QUESTION_STARTER):
+    # preprocess the message
+    user_message = get_raw_text(message.content)
+    if user_message.startswith(QUESTION_STARTER):
         return True
 
 
@@ -46,10 +49,11 @@ def qna_action(message, client=None, history=[]):
     str:
         Pymon LLM response through discord API
     """
-    query = message.content.replace(QUESTION_STARTER, '')
     if client:
         query = message.content.replace(client.user.mention, '')
-
+    else:
+        # maybe add query preprocessing using gemini to remove "tell me pymon" in a smarter way
+        query = message.content
     # get the LLM response
     response = get_llm_response(query, history=history)
     return response

--- a/api/utils.py
+++ b/api/utils.py
@@ -21,3 +21,13 @@ def clean_message(text):
         return cleaned_text
     else:
         return text
+
+
+def get_raw_text(text):
+    # turn to lowercase, remove punctuation, remove extra spaces and trailing spaces
+    text = text.lower()
+    text = re.sub(r'[^\w\s]', '', text)
+    text = re.sub(r'\s+', ' ', text)
+    text = text.strip()
+
+    return text


### PR DESCRIPTION
- bot now successfully triggers regardless of casing and punctuation
- no removal of the trigger phrase from the query to LLM